### PR TITLE
新增auth加权轮询，调增终端日志颜色

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,21 @@ project-root/
 
 ## 功能
 - [x] 支持图片上传
-- [x] 支持gpt-4o
+- [x] 支持`gpt-4o`
 - [x] 模拟对话隔离（根据客户前一条消息作为key）
-- [x] 支持多账号轮询（AUTHORIZATION = auth1,auth2,auth3 ）
-- [x] 支持proxy：HTTPS_PROXIES = proxy1,proxy2
-- [x] 新增 “ /v1/images/generations” 路由，兼容OPENAI文生图报文格式
+- [x] 支持多账号加权轮询`（AUTHORIZATION = auth1-权重,auth2-权重,auth3 ）`，如`（AUTHORIZATION = auth1-1,auth2-2,auth3 ）`，兼容前一个版本的`AUTHORIZATION`，不带默认为1，即`（AUTHORIZATION = auth1,auth2,auth3）`等于`（AUTHORIZATION = auth1-1,auth2-1,auth3-1）`
+- [x] 支持proxy：`HTTPS_PROXIES = proxy1,proxy2`
+- [x] 新增 `/v1/images/generations` 路由，兼容OPENAI文生图报文格式
 
 ## 部署 
 ### docker
 
 ```bash
+# 默认权重
 docker run --name popai2api --restart=always -d -p 3000:3000 -e AUTHORIZATION = {{auth1,auth2,auth3}} hulu365/popai2api:latest
+
+# 定义权重
+docker run --name popai2api --restart=always -d -p 3000:3000 -e AUTHORIZATION = {{auth1-1,auth2-3,auth3-5}} hulu365/popai2api:latest
 ```
 
 ## draw

--- a/app/config.py
+++ b/app/config.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import random
+from colorlog import ColoredFormatter
 
 IGNORED_MODEL_NAMES = ["gpt-4", "gpt-3.5", "websearch", "dall-e-3", "gpt-4o"]
 IMAGE_MODEL_NAMES = ["dalle3", "dalle-3", "dall-e-3"]
@@ -12,11 +13,32 @@ SOCKS_PROXIES = os.getenv("SOCKS_PROXIES")
 
 
 def configure_logging():
-    extended_log_format = (
-        '%(asctime)s | %(levelname)s | %(name)s | '
-        '%(process)d | %(filename)s:%(lineno)d | %(funcName)s | %(message)s'
+    log_format = (
+        '%(log_color)s%(asctime)s | %(levelname)s | %(name)s | '
+        '%(process)d | %(filename)s:%(lineno)d | %(funcName)s | %(message)s%(reset)s'
     )
-    logging.basicConfig(level=logging.DEBUG, format=extended_log_format)
+    # Create a colored formatter
+    formatter = ColoredFormatter(
+        log_format,
+        datefmt=None,
+        reset=True,
+        log_colors={
+            'DEBUG': 'cyan',
+            'INFO': 'green',
+            'WARNING': 'yellow',
+            'ERROR': 'red',
+            'CRITICAL': 'red,bg_white',
+        }
+    )
+
+    # Create a console handler
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    # Get the root logger
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(console_handler)
 
 
 def _get_proxies_from_env(env_var):

--- a/app/config.py
+++ b/app/config.py
@@ -38,7 +38,10 @@ def configure_logging():
     # Get the root logger
     logger = logging.getLogger()
     logger.setLevel(logging.DEBUG)
-    logger.addHandler(console_handler)
+
+    # Avoid adding duplicate handlers
+    if not any(isinstance(handler, logging.StreamHandler) for handler in logger.handlers):
+        logger.addHandler(console_handler)
 
 
 def _get_proxies_from_env(env_var):

--- a/app/routes.py
+++ b/app/routes.py
@@ -59,7 +59,9 @@ def get_channel_id(hash_value, token, model_name, content, template_id):
 def fetch(req):
     if req.method == "OPTIONS":
         return handle_options_request()
-    token = get_next_auth_token(AUTH_TOKEN)
+
+    # 获取加权轮询后的Token
+    token = get_next_auth_token()
     messages, model_name, prompt, user_stream = get_request_parameters(req.get_json())
     model_to_use = map_model_name(model_name)
     template_id = 2000000 if model_name in IMAGE_MODEL_NAMES else ''

--- a/app/weight.py
+++ b/app/weight.py
@@ -1,0 +1,59 @@
+from app.config  import AUTH_TOKEN
+
+# ----- 加权轮询相关全局变量 Start---------
+# 默认权重
+WEIGHT_DEFAULT = 1
+# TOKENS 数组
+TOKENS = []
+# TOKENS 初始权重数组
+TOKEN_WEIGHTS = []
+# 当前权重
+CURRENT_WEIGHT = 0
+# 当前权重索引
+CURRENT_INDEX = -1
+# TOKEN 总数
+TOKENS_NUM = 0
+# 最大权重
+MAX_WEIGHT = 0
+# 加权权重
+GCD_WEIGHT = 0
+# ----- 加权轮询相关全局变量 End---------
+
+
+def gcd(a, b):
+    while b:
+        a, b = b, a % b
+    return a
+
+
+def find_gcd_of_weights(weights):
+    gcd_result = weights[0]
+    for weight in weights[1:]:
+        gcd_result = gcd(gcd_result, weight)
+    return gcd_result
+
+
+#  初始化 tokens 权重
+def initialize_token_weights():
+    global TOKEN_WEIGHTS, TOKENS_NUM, CURRENT_WEIGHT, TOKENS_WEIGHTS,MAX_WEIGHT,GCD_WEIGHT
+    if not AUTH_TOKEN:
+        raise ValueError("No tokens provided.")
+
+    auth_tokens = AUTH_TOKEN.split(',')
+
+    for auth_token in auth_tokens:
+        token_parts = auth_token.split('---')
+        token = token_parts[0].strip()
+        weight = int(token_parts[1]) if len(token_parts) > 1 else WEIGHT_DEFAULT
+        # 把 token 按顺序放入 tokens 数组中
+        TOKENS.append(token)
+        # 把 token 的权重按顺序放入 tokens_weights 中
+        TOKEN_WEIGHTS.append(weight)
+
+    # 获取最大权重
+    MAX_WEIGHT = max(TOKEN_WEIGHTS)
+    GCD_WEIGHT = find_gcd_of_weights(TOKEN_WEIGHTS)
+    TOKENS_NUM = len(TOKENS)
+
+# 初始化 tokens 权重
+initialize_token_weights()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.3
 Flask-Cors==4.0.0
 requests==2.31.0
+colorlog==6.8.2


### PR DESCRIPTION
1. 新增`auth`加权轮询，应对auth不同权重的轮询。比如，同时有Pro和Unlimited的2种付费权限账号，Pro 月使用GPT-4o 的次数为200 次，Unlimited 为 无限次。
2. 优化终端日志颜色，全部红色看着脑壳痛，且不能直观分析日志。